### PR TITLE
Improve svd load cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@ $ pip3 install -r ./requirements.txt
 
 Then simply add gdb-dashboad-svd.py in your ~/.gdbinit.d/ directory.
 
+### Load SVD files
+In order to overload the `dashboard svd load` command, you have to define the following environment variable (in your .bashrc for example):
+```
+export SVD_FOLDER="$HOME/cmsis-svd/data/"
+```
+
+Structure of the folder should be `vendor/device.svd`. For example, the nRF5340 SVD file should be in `$HOME/cmsis-svd/data/Nordic/nRF5340.svd`.
+
+You can download a lot of SVD files from [cmsis-svd-data](https://github.com/cmsis-svd/cmsis-svd-data/tree/main/data).
+
 ## Usage
 
 All commands benefit from a usefull completion.

--- a/gdb-dashboard-svd.py
+++ b/gdb-dashboard-svd.py
@@ -10,8 +10,6 @@ class SVDDevicesHelper():
         self.__devices = []
 
     def load(self, files):
-        self.__devices.clear()
-
         for f in files:
             f = os.path.expandvars(os.path.expanduser(f))
             device = SVDParser.for_xml_file(f).get_device()
@@ -276,6 +274,17 @@ class SVD(SVDDevicesHelper, Dashboard.Module):  # noqa: F821
     def __init__(self):
         super().__init__()
         self.__registers = []
+        self.vendors = {}
+        svd_folder = os.getenv('SVD_FOLDER')
+
+        if svd_folder:
+            vendor_names = [entry.name for entry in os.scandir(
+                svd_folder) if entry.is_dir()]
+            for vendor in vendor_names:
+                vendor_path = os.path.join(svd_folder, vendor)
+                fnames = [entry.name for entry in os.scandir(
+                    vendor_path) if entry.is_file() and entry.name.lower().endswith(".svd")]
+                self.vendors[vendor] = fnames
 
     def label(self):
         names = self.devices_name()
@@ -308,13 +317,47 @@ class SVD(SVDDevicesHelper, Dashboard.Module):  # noqa: F821
         return out
 
     def load(self, arg):
-        if not arg:
-            raise Exception('No file specified')
+        args = gdb.string_to_argv(arg)
+        if len(args) == 1:
+            gdb.write("Loading SVD file {}...\n".format(args[0]))
+            f = args[0]
+        elif len(args) == 2:
+            gdb.write("Loading SVD file {}/{}...\n".format(args[0], args[1]))
+            f = os.path.join(os.getenv('SVD_FOLDER'), args[0], args[1])
+        else:
+            raise gdb.GdbError(
+                "Usage: svd load <vendor> <device.svd> or svd_load <path/to/filename.svd>\n")
+        try:
+            SVDDevicesHelper.load(self, gdb.string_to_argv(f))
+            SVDInfo(self)
+            SVDGet(self)
+        except Exception as e:
+            raise gdb.GdbError(
+                "Could not load SVD file {} : {}...\n".format(f, e))
 
-        self.clear(None)
-        SVDDevicesHelper.load(self, gdb.string_to_argv(arg))
-        SVDInfo(self)
-        SVDGet(self)
+    def load_complete(self, text, word):
+        if len(self.vendors) == 0:
+            return gdb.COMPLETE_FILENAME
+        if word is None:
+            return gdb.COMPLETE_NONE
+
+        args = gdb.string_to_argv(text)
+        num_args = len(args)
+        if text.endswith(" "):
+            num_args += 1
+        if not text:
+            num_args = 1
+
+        # "svd load <tab>" or "svd_load ST<tab>"
+        if num_args == 1:
+            prefix = word.lower()
+            return [vendor for vendor in self.vendors if vendor.lower().startswith(prefix)]
+        # "svd load STMicro<tab>" or "svd_load STMicro STM32F1<tab>"
+        elif num_args == 2 and args[0] in self.vendors:
+            prefix = word.lower()
+            filenames = self.vendors[args[0]]
+            return [fname for fname in filenames if fname.lower().startswith(prefix)]
+        return gdb.COMPLETE_NONE
 
     def get_register(self, peripheral, register, fmt=None):
         p = self.get_peripheral(peripheral)
@@ -389,7 +432,7 @@ class SVD(SVDDevicesHelper, Dashboard.Module):  # noqa: F821
             'load': {
                 'action': self.load,
                 'doc': 'Load SVD files',
-                'complete': gdb.COMPLETE_FILENAME,
+                'complete': self.load_complete,
             },
             'add': {
                 'action': self.add,


### PR DESCRIPTION
Now, we can define an env variable that hold a folder with all svd files sort by `Vendor/Device`.
Set the completion to easily select the right svd file

In order to overload the `dashboard svd load` command, you have to define the following environment variable (in your .bashrc for example):
```
export SVD_FOLDER="$HOME/cmsis-svd/data/"
```

Structure of the folder should be `vendor/device.svd`. For example, the nRF5340 SVD file should be in `$HOME/cmsis-svd/data/Nordic/nRF5340.svd`.